### PR TITLE
GET /posts/:postID実装

### DIFF
--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -38,6 +38,7 @@ func Start() {
 	api := e.Group("/api")
 	api.POST("/posts", ph.PostPostsHandler)
 	api.GET("/posts", ph.GetPostsHandler)
+	api.GET("/posts/:postID", ph.GetPostHandler)
 
 	api.POST("/posts/:postID/reactions/:reactionID", rh.PostReactionHandler)
 

--- a/backend/handler/reaction.go
+++ b/backend/handler/reaction.go
@@ -15,6 +15,7 @@ import (
 
 type ReactionRepository interface {
 	GetReactionsByPostID(ctx context.Context, postID uuid.UUID) ([]*domain.Reaction, error)
+	GetReactionsByPostIDs(ctx context.Context, postIDs []uuid.UUID) (map[uuid.UUID][]*domain.Reaction, error)
 	PostReaction(ctx context.Context, postID uuid.UUID, reactionID int, userName string) error
 }
 

--- a/backend/repository/post.go
+++ b/backend/repository/post.go
@@ -129,3 +129,26 @@ func (pr *PostRepository) GetPost(ctx context.Context, postID uuid.UUID) (*domai
 		CreatedAt:        p.CreatedAt,
 	}, nil
 }
+
+func (pr *PostRepository) GetChildren(ctx context.Context, parentID uuid.UUID) ([]*domain.Post, error) {
+	var posts []post
+	err := pr.db.Select(&posts, "SELECT * FROM posts WHERE parent_id = ? ORDER BY created_at", parentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get children: %w", err)
+	}
+
+	var domainPosts []*domain.Post
+	for _, p := range posts {
+		domainPosts = append(domainPosts, &domain.Post{
+			ID:               p.ID,
+			UserName:         p.UserName,
+			OriginalMessage:  p.OriginalMessage,
+			ConvertedMessage: p.ConvertedMessage,
+			ParentID:         p.ParentID,
+			RootID:           p.RootID,
+			CreatedAt:        p.CreatedAt,
+		})
+	}
+
+	return domainPosts, nil
+}

--- a/backend/repository/post.go
+++ b/backend/repository/post.go
@@ -108,3 +108,24 @@ func (pr *PostRepository) GetLatestPosts(ctx context.Context, limit int) ([]*dom
 
 	return domainPosts, nil
 }
+
+func (pr *PostRepository) GetPost(ctx context.Context, postID uuid.UUID) (*domain.Post, error) {
+	var p post
+	err := pr.db.Get(&p, "SELECT * FROM posts WHERE id = ?", postID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("post not found: %w", err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get post: %w", err)
+	}
+
+	return &domain.Post{
+		ID:               p.ID,
+		UserName:         p.UserName,
+		OriginalMessage:  p.OriginalMessage,
+		ConvertedMessage: p.ConvertedMessage,
+		ParentID:         p.ParentID,
+		RootID:           p.RootID,
+		CreatedAt:        p.CreatedAt,
+	}, nil
+}

--- a/backend/repository/post.go
+++ b/backend/repository/post.go
@@ -178,6 +178,10 @@ func (pr *PostRepository) GetAncestors(ctx context.Context, postID uuid.UUID) ([
 }
 
 func (pr *PostRepository) GetChildrenCountByParentIDs(ctx context.Context, parentIDs []uuid.UUID) (map[uuid.UUID]int, error) {
+	if len(parentIDs) == 0 {
+		return nil, nil
+	}
+
 	query, args, err := sqlx.In("SELECT parent_id, COUNT(*) FROM posts WHERE parent_id IN (?) GROUP BY parent_id", parentIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create query: %w", err)

--- a/backend/repository/reaction.go
+++ b/backend/repository/reaction.go
@@ -62,3 +62,39 @@ func (rr *ReactionRepository) PostReaction(ctx context.Context, postID uuid.UUID
 
 	return nil
 }
+
+func (rr *ReactionRepository) GetReactionsByPostIDs(ctx context.Context, postIDs []uuid.UUID) (map[uuid.UUID][]*domain.Reaction, error) {
+	query, args, err := sqlx.In(
+		"SELECT post_id, reaction_id, COUNT(*) as count FROM posts_reactions WHERE post_id IN (?) GROUP BY post_id, reaction_id",
+		postIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	rows, err := rr.DB.Queryx(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reactions by post ids: %w", err)
+	}
+	defer rows.Close()
+
+	reactionsMap := make(map[uuid.UUID][]*domain.Reaction, len(postIDs))
+	for rows.Next() {
+		var postID uuid.UUID
+		var reactionID int
+		var count int
+		if err := rows.Scan(&postID, &reactionID, &count); err != nil {
+			return nil, fmt.Errorf("failed to scan: %w", err)
+		}
+
+		if _, ok := reactionsMap[postID]; !ok {
+			reactionsMap[postID] = make([]*domain.Reaction, 0, 10)
+		}
+		reactionsMap[postID] = append(reactionsMap[postID], &domain.Reaction{
+			PostID:     postID,
+			ReactionID: reactionID,
+			Count:      count,
+		})
+	}
+
+	return reactionsMap, nil
+}

--- a/backend/repository/reaction.go
+++ b/backend/repository/reaction.go
@@ -64,6 +64,10 @@ func (rr *ReactionRepository) PostReaction(ctx context.Context, postID uuid.UUID
 }
 
 func (rr *ReactionRepository) GetReactionsByPostIDs(ctx context.Context, postIDs []uuid.UUID) (map[uuid.UUID][]*domain.Reaction, error) {
+	if len(postIDs) == 0 {
+		return nil, nil
+	}
+
 	query, args, err := sqlx.In(
 		"SELECT post_id, reaction_id, COUNT(*) as count FROM posts_reactions WHERE post_id IN (?) GROUP BY post_id, reaction_id",
 		postIDs)


### PR DESCRIPTION
- **:sparkles: GetPostHandlerを追加**
- **:sparkles: repositoryのGetPostメソッドを追加**
- **:sparkles: handlerのGetPostHandlerでレスポンス変更に対応**
- **:sparkles: repositoryにGetChildrenメソッドを追加**
- **:sparkles: repositoryのGetAncestorsメソッドを追加**
- **:sparkles: repositoryでGetChildrenCountByParentIDsを追加**
- **:sparkles: repositoryでGetReactionsByPostIDsを実装**
- **:bug: sqlx.In() に空のスライスを渡すとエラーになるのを修正**
- **:bug: GetAncestorsでcreated_atを見ていなかったのを修正**
