### PR TITLE
ランダムなconverter実装

### DIFF
--- a/backend/converter/random/converter.go
+++ b/backend/converter/random/converter.go
@@ -1,0 +1,31 @@
+package random
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/traP-jp/h24s_24/domain"
+)
+
+type PostRepository interface {
+	GetRandomPost(ctx context.Context) (domain.Post, error)
+}
+
+type Converter struct {
+	pr PostRepository
+}
+
+func NewConverter(pr PostRepository) *Converter {
+	return &Converter{pr: pr}
+}
+
+func (cvt *Converter) ConvertMessage(ctx context.Context, originalMessage string) (string, error) {
+	post, err := cvt.pr.GetRandomPost(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get random post: %w", err)
+	}
+
+	converted := fmt.Sprintf("%s\nそれはそうと、%s", originalMessage, post.ConvertedMessage)
+
+	return converted, nil
+}

--- a/backend/converter/random/converter.go
+++ b/backend/converter/random/converter.go
@@ -8,7 +8,7 @@ import (
 )
 
 type PostRepository interface {
-	GetRandomPost(ctx context.Context) (domain.Post, error)
+	GetRandomPost(ctx context.Context) (*domain.Post, error)
 }
 
 type Converter struct {

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/traP-jp/h24s_24/converter"
 	"github.com/traP-jp/h24s_24/converter/mock"
+	"github.com/traP-jp/h24s_24/converter/random"
 	"github.com/traP-jp/h24s_24/repository"
 )
 
@@ -30,6 +31,9 @@ func Start() {
 	if local, err := strconv.ParseBool(os.Getenv("LOCAL")); err == nil && local {
 		log.Println("using mock converter")
 		cvt = &mock.MockConverter{}
+	} else if withoutOpenAI, err := strconv.ParseBool(os.Getenv("WITHOUT_OPENAI")); err == nil && withoutOpenAI {
+		log.Println("using random converter")
+		cvt = random.NewConverter(pr)
 	} else {
 		cvt, err = converter.NewOpenAI()
 		if err != nil {

--- a/backend/repository/post.go
+++ b/backend/repository/post.go
@@ -262,3 +262,24 @@ func (pr *PostRepository) GetChildrenCountByParentIDs(ctx context.Context, paren
 
 	return counts, nil
 }
+
+func (pr *PostRepository) GetRandomPost(ctx context.Context) (*domain.Post, error) {
+	var p post
+	err := pr.db.Get(&p, "SELECT * FROM posts ORDER BY RAND() LIMIT 1")
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("post not found: %w", err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get post: %w", err)
+	}
+
+	return &domain.Post{
+		ID:               p.ID,
+		UserName:         p.UserName,
+		OriginalMessage:  p.OriginalMessage,
+		ConvertedMessage: p.ConvertedMessage,
+		ParentID:         p.ParentID,
+		RootID:           p.RootID,
+		CreatedAt:        p.CreatedAt,
+	}, nil
+}


### PR DESCRIPTION
OPEN AIのAPIをやめた後の実装を追加した。
「{original_message}\nそれはそうと、{ランダムな投稿の変換後メッセージ}」に変換する。

- **:sparkles: randomのconverterを実装**
- **:sparkles: repositoryでGetRandomPostを追加**
