### PR TITLE
feat: トレンドを全期間で集計するように

### DIFF
--- a/backend/handler/reaction.go
+++ b/backend/handler/reaction.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
@@ -18,7 +17,7 @@ type ReactionRepository interface {
 	DeleteReaction(ctx context.Context, postID uuid.UUID, reactionID int, userName string) error
 	GetReactionsByPostID(ctx context.Context, postID uuid.UUID) ([]*domain.Reaction, error)
 	GetReactionsByPostIDs(ctx context.Context, postIDs []uuid.UUID) (map[uuid.UUID][]*domain.Reaction, error)
-	GetReactionCountsGroupedByPostID(ctx context.Context, reactionID *int, since time.Time, until time.Time) ([]*domain.ReactionCount, error)
+	GetReactionCountsGroupedByPostID(ctx context.Context, reactionID *int) ([]*domain.ReactionCount, error)
 	PostReaction(ctx context.Context, postID uuid.UUID, reactionID int, userName string) error
 	GetReactionsByUserName(ctx context.Context, postID uuid.UUID, userName string) ([]*domain.UserReaction, error)
 }

--- a/backend/handler/trend.go
+++ b/backend/handler/trend.go
@@ -32,8 +32,6 @@ type getTrendResponse struct {
 }
 
 func (tr *TrendHandler) GetTrendHandler(c echo.Context) error {
-	until := time.Now()
-	since := until.Add(-time.Hour * 12)
 	postLimit := 30
 
 	loginUser, err := getUserName(c)
@@ -54,7 +52,7 @@ func (tr *TrendHandler) GetTrendHandler(c echo.Context) error {
 		reactionIDRef = &reactionID
 	}
 
-	counts, err := tr.rr.GetReactionCountsGroupedByPostID(ctx, reactionIDRef, since, until)
+	counts, err := tr.rr.GetReactionCountsGroupedByPostID(ctx, reactionIDRef)
 	if err != nil {
 		log.Printf("failed to get reactions: %v\n", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get reactions")

--- a/backend/repository/reaction.go
+++ b/backend/repository/reaction.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -76,20 +75,16 @@ type reactionCount struct {
 	Count  int       `db:"reaction_count"`
 }
 
-func (rr *ReactionRepository) GetReactionCountsGroupedByPostID(ctx context.Context, reactionID *int, since time.Time, until time.Time) ([]*domain.ReactionCount, error) {
-	if !since.Before(until) {
-		return nil, errors.New("invalid arguments")
-	}
-
+func (rr *ReactionRepository) GetReactionCountsGroupedByPostID(ctx context.Context, reactionID *int) ([]*domain.ReactionCount, error) {
 	var (
 		counts []*reactionCount
 		err    error
 	)
 
 	if reactionID == nil {
-		err = rr.DB.Select(&counts, "SELECT post_id, COUNT(*) AS reaction_count FROM posts_reactions WHERE created_at BETWEEN ? AND ? GROUP BY post_id ORDER BY reaction_count DESC", since, until)
+		err = rr.DB.Select(&counts, "SELECT post_id, COUNT(*) AS reaction_count FROM posts_reactions WHERE created_at GROUP BY post_id ORDER BY reaction_count DESC")
 	} else {
-		err = rr.DB.Select(&counts, "SELECT post_id, COUNT(*) AS reaction_count FROM posts_reactions WHERE reaction_id=? AND created_at BETWEEN ? AND ? GROUP BY post_id ORDER BY reaction_count DESC", *reactionID, since, until)
+		err = rr.DB.Select(&counts, "SELECT post_id, COUNT(*) AS reaction_count FROM posts_reactions WHERE reaction_id=? AND created_at GROUP BY post_id ORDER BY reaction_count DESC", *reactionID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get reactions: %w", err)


### PR DESCRIPTION
OpenAIによるconvertをやめた後は投稿が減ると予想され、過去12時間のトレンドが意味をなさなくなる

なので全期間で集計するようにする